### PR TITLE
add LogOptions enum

### DIFF
--- a/src/log_options.rs
+++ b/src/log_options.rs
@@ -11,7 +11,7 @@ enum LogOptions {
 impl FromStr for LogOptions {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Options, ()> {
+    fn from_str(s: &str) -> Result<LogOptions, ()> {
         match s {
             "debug" => Ok(LogOptions::Debug),
             "info" => Ok(LogOptions::Info),

--- a/src/log_options.rs
+++ b/src/log_options.rs
@@ -1,0 +1,25 @@
+
+enum LogOptions {
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Fatal,
+    Paniic
+}
+
+impl FromStr for LogOptions {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Options, ()> {
+        match s {
+            "debug" => Ok(LogOptions::Debug),
+            "info" => Ok(LogOptions::Info),
+            "warn" => Ok(LogOptions::Warn),
+            "error" => Ok(LogOptions::Error),
+            "fatal" => Ok(LogOptions::Fatal),
+            "panic" => Ok(LogOptions::Paniic),
+            _ => Err(()),
+        }
+    }
+}


### PR DESCRIPTION
enum LogOprions would be used in number of binaries to parse CLI option to set output level.